### PR TITLE
GitHubのIssueやPull Requestの確認が行える

### DIFF
--- a/hubot-scripts.json
+++ b/hubot-scripts.json
@@ -1,1 +1,14 @@
-[]
+[
+  "github-activity.coffee",
+  "github-commiters.coffee",
+  "github-commit-link.coffee",
+  "github-commits.coffee",
+  "github-credentials.coffee",
+  "github-issue-link.coffee",
+  "github-issues.coffee",
+  "github-merge.coffee",
+  "github-pull-request-notifier.coffee",
+  "github-pulls.coffee",
+  "github-search.coffee",
+  "github-status.coffee"
+]

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "author": "leckyyyyyyy",
   "description": "A simple helpful robot for your Company",
   "dependencies": {
+    "date-utils": "^1.2.16",
+    "githubot": "^1.0.0",
+    "gitio2": "^3.0.0",
     "hubot": "^2.12.0",
     "hubot-diagnostics": "0.0.1",
     "hubot-google-images": "^0.1.4",
@@ -18,7 +21,9 @@
     "hubot-scripts": "^2.5.16",
     "hubot-shipit": "^0.1.2",
     "hubot-slack": "^3.3.0",
-    "hubot-youtube": "^0.1.2"
+    "hubot-youtube": "^0.1.2",
+    "underscore": "^1.8.3",
+    "underscore.string": "^3.0.3"
   },
   "engines": {
     "node": "0.10.x"


### PR DESCRIPTION
Issueの確認
`hubot show issues for <repo>`
Pull Requestの確認
`hubot show <repo> pulls`

HubotでGitHubを連携するときに必要な環境変数
- HUBOT_GITHUB_ORG  
  GitHubのプライベートスペース(https://github.com/[プライベートスペース])
- HUBOT_GITHUB_REPO  
  対象となるリポジトリを指定
- HUBOT_GITHUB_TOKEN  
  [GitHubのPersonal access tokens](https://github.com/settings/tokens)の`Generate new token`で取得した値
- HUBOT_GITHUB_USER  
  GitHubのリポジトリにアクセス可能な実在するユーザー名

`HUBOT_GITHUB_REPO`が必要なscriptは動作しないです。
Hubotを特定のリポジトリに関連付けて連携する場合は必要になりますが、
全体を参照するような場合は不要と思われます。

参考
[hubot-scriptsを使おう!(GitHub連携)](http://qiita.com/hirosat/items/dd292490b12b6ce8bdbc#github%E9%80%A3%E6%90%BA)
